### PR TITLE
Simple function based API, easy to dlopen/dlsym

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ SET(COMMON_SRC
   multiplane.cpp
   context.cu
   util/cosmology.cu
+  multiplane_api.cpp
 )
 
 add_library(lens_common SHARED

--- a/src/multiplane_api.cpp
+++ b/src/multiplane_api.cpp
@@ -1,0 +1,49 @@
+#include "context.h"
+
+typedef MultiPlaneContext* MultiPlaneCtx;
+typedef Vector2D<float> MPCUXY;
+typedef PlummerParams MPCUInitialPlummerInfo;
+
+#define MULTIPLANE_INTERNAL_USE
+#include "multiplane_api.h"
+
+using namespace std;
+
+int mpcuInitMultiPlaneCalculation(
+		double angularUnit,
+		double h, double W_m, double W_r, double W_v, double w,
+		const vector<float> &lensRedshifts,
+		const vector<vector<MPCUInitialPlummerInfo>> &fixedPlummerParameters, 
+		const vector<float> &sourceRedshifts,
+		const vector<vector<MPCUXY>> &theta, 
+		MultiPlaneCtx *pCtx)
+{
+	MultiPlaneContext *pContext = new MultiPlaneContext(angularUnit, Cosmology(h, W_m, W_r, W_v, w));
+	int status = pContext->init(lensRedshifts, fixedPlummerParameters, sourceRedshifts);
+	if (status < 0)
+	{
+		delete pContext;
+		return status;
+	}
+
+	pContext->setThetas(theta);
+
+	*pCtx = pContext;
+	return 0;
+}
+
+int mpcuCalculateSourcePositions(MultiPlaneCtx ctx, const vector<vector<float>> &massFactors)
+{
+	return ctx->calculatePositions(massFactors);
+}
+
+const vector<MPCUXY> &mpcuGetSourcePositions(MultiPlaneCtx ctx, int srcIdx)
+{
+	return ctx->getSourcePositions(srcIdx);
+}
+
+void mpcuClearContext(MultiPlaneCtx ctx)
+{
+	delete ctx;
+}
+

--- a/src/multiplane_api.h
+++ b/src/multiplane_api.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <vector>
+
+extern "C" {
+
+#ifndef MULTIPLANE_INTERNAL_USE
+typedef void* MultiPlaneCtx;
+
+// Gewoon iets voor een X/Y positie. Hier worden floats
+// gebruikt, wat wil zeggen dat die waarden uitgedrukt worden
+// in de opgegeven 'angularUnit' (zie verder)
+struct MPCUXY
+{
+	float X, Y;
+};
+
+// Vaste parameters voor de plummer basisfuncties. Aan de massa
+// zullen we verderop dan iets veranderen door een extra factor
+// op te geven
+struct MPCUInitialPlummerInfo
+{
+	MPCUXY position;
+	float width; // ook weer uitgedrukt in 'angularUnit' (dus bvb X*angularUnit (als double) geeft de echte waarde)
+	double initialMass; // dit is gewoon in kg uitgedrukt.
+};
+#endif
+
+// De functies van de API; een 'int' als returnwaarde is negatief bij een
+// error, en 0 als alles ok ging
+
+// Initialiseer een MultiPlaneCtx (wordt via laatste parameter teruggegeven)
+int mpcuInitMultiPlaneCalculation(
+		// Hoeken (dingen in XY struct) zijn uitgedrukt in deze eenheid,
+		// dwz als veelvouden van deze waarde
+		double angularUnit,
+
+		// Kosmologie parameters	
+		double h, double W_m, double W_r, double W_v, double w,
+
+		// De roodverschuivingen van de lensvlakken
+		const std::vector<float> &lensRedshifts,
+
+		// Voor elk lensvlak, de startparameters van alle plummers.
+		const std::vector<std::vector<MPCUInitialPlummerInfo>> &fixedPlummerParameters, 
+
+		// De roodverschuivingen van alle bronnen
+		const std::vector<float> &sourceRedshifts,
+
+		// Per bron, de theta-vectoren (ook uitgedrukt in 'angularUnit')
+		const std::vector<std::vector<MPCUXY>> &theta, 
+
+		// Als initialisatie werkte
+		MultiPlaneCtx *pCtx);
+
+// Voor een geinitialiseerde context, pas de initiele massa's aan volgens 
+// massFactors en bereken de beta-vectoren voor alle bronnen
+int mpcuCalculateSourcePositions(MultiPlaneCtx ctx, const std::vector<std::vector<float>> &massFactors);
+
+// Voor de bron met index 'srcIdx', geef de berekende beta-posities terug
+const std::vector<MPCUXY> &mpcuGetSourcePositions(MultiPlaneCtx ctx, int srcIdx);
+
+// Alles weer opruimen
+void mpcuClearContext(MultiPlaneCtx ctx);
+
+} // extern "C"
+


### PR DESCRIPTION
Exports the following function with C-name mangling, so can be
accessed using e.g. dlsym:
 mpcuInitMultiPlaneCalculation
 mpcuCalculateSourcePositions
 mpcuGetSourcePositions
 mpcuClearContext