### PR TITLE
Bugfix: sources should not be sorted on redshift

### DIFF
--- a/src/multiplane.cpp
+++ b/src/multiplane.cpp
@@ -12,7 +12,11 @@ void MultiplaneBuilder::addPlane(CompositeLensBuilder &lensbuilder) {
 
 void MultiplaneBuilder::prepare() {
     std::sort(m_builders.begin(), m_builders.end());
-    std::sort(m_source_z.begin(), m_source_z.end());
+
+	// This causes incorrect results if the source redshifts are not provided
+	// in an ordered fashion. Without the sorting both sorted and unsorted
+	// input appears to work correctly.
+    // std::sort(m_source_z.begin(), m_source_z.end());
 
     // Calculate distances for all the lenses
     double sz, lz, Di, Dji, Dd;


### PR DESCRIPTION
If the sort is enabled, the results are not correct when the sources
are not ordered on redshift. Without the sort, both cases (sources
sorted or not sorted on redshift) appear to work fine.